### PR TITLE
Update apt-get cache before installing deps (Fixes failing docs generation)

### DIFF
--- a/.github/workflows/nqp-docs.yml
+++ b/.github/workflows/nqp-docs.yml
@@ -23,6 +23,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install python-sphinx
           python -m pip install sphinx-autodoc-typehints
       - name: build-docs


### PR DESCRIPTION
I tested it on the develop branch of my fork and it worked so I think this is the issue.