### PR TITLE
hotfix/allow_projectiles_in_tile_info

### DIFF
--- a/scripts/nqp/ui_elements/actor_info.py
+++ b/scripts/nqp/ui_elements/actor_info.py
@@ -160,17 +160,20 @@ class ActorInfo(Window):
 
                 info.append(("image", section_break_image))
 
-            #  get traits
-            traits = world.get_entitys_component(entity, Traits)
-            if traits:
-                names = ""
-                for name in traits.names:
-                    # if more than one trait add a separator
-                    if len(names) > 1:
-                        names += ", "
-                    names += f"{name}"
-                info.append(("text", names))
-                info.append(("image", section_break_image))
+            #  get traits (skip for projectiles)
+            try:
+                traits = world.get_entitys_component(entity, Traits)
+                if traits:
+                    names = ""
+                    for name in traits.names:
+                        # if more than one trait add a separator
+                        if len(names) > 1:
+                            names += ", "
+                        names += f"{name}"
+                    info.append(("text", names))
+                    info.append(("image", section_break_image))
+            except:
+                pass
 
             # get afflictions
             afflictions = world.get_entitys_component(entity, Afflictions)

--- a/scripts/nqp/ui_elements/tile_info.py
+++ b/scripts/nqp/ui_elements/tile_info.py
@@ -80,16 +80,19 @@ class TileInfo(Panel):
                         current_info.append(f"Health: {resources.health}")
                         current_info.append(f"Stamina: {resources.stamina}")
 
-                    #  get traits
-                    traits = world.get_entitys_component(entity, Traits)
-                    if traits:
-                        names = ""
-                        for name in traits.names:
-                            # if more than one trait add a separator
-                            if len(names) > 1:
-                                names += ", "
-                            names += f"{name}"
-                        current_info.append(names)
+                    #  get traits (handle projectile exception)
+                    try:
+                        traits = world.get_entitys_component(entity, Traits)
+                        if traits:
+                            names = ""
+                            for name in traits.names:
+                                # if more than one trait add a separator
+                                if len(names) > 1:
+                                    names += ", "
+                                names += f"{name}"
+                            current_info.append(names)
+                    except:
+                        pass
 
                     # add collected info to main info
                     info.append(current_info)


### PR DESCRIPTION
Fixes #242. The formatting is questionable. The croc projectile names are too long and stats like health/stamina are shown. A feature issue should probably be opened with the specifications for the formatting of projectiles.