### PR TITLE
hotfix/stopped_double_movement

### DIFF
--- a/scripts/engine/internal/event.py
+++ b/scripts/engine/internal/event.py
@@ -60,12 +60,12 @@ class EventHub:
         """
         self.subscribers[event_type].remove(subscriber)
 
-    def peek(self, event_type: EventType):
+    def peek(self, event: Event):
         """
         Check if an event exists in the queue.
         """
-        for event in self.events:
-            if isinstance(event, event_type):
+        for e in self.events:
+            if isinstance(e, event): #type: ignore
                 return True
         return False
 

--- a/scripts/engine/internal/event.py
+++ b/scripts/engine/internal/event.py
@@ -60,6 +60,15 @@ class EventHub:
         """
         self.subscribers[event_type].remove(subscriber)
 
+    def peek(self, event_type: EventType):
+        """
+        Check if an event exists in the queue.
+        """
+        for event in self.events:
+            if isinstance(event, event_type):
+                return True
+        return False
+
     def update(self):
         """
         Notify subscribers of their registered event.

--- a/scripts/engine/internal/event.py
+++ b/scripts/engine/internal/event.py
@@ -60,7 +60,7 @@ class EventHub:
         """
         self.subscribers[event_type].remove(subscriber)
 
-    def peek(self, event: Event): #type: ignore
+    def peek(self, event):
         """
         Check if an event exists in the queue.
         """

--- a/scripts/engine/internal/event.py
+++ b/scripts/engine/internal/event.py
@@ -60,7 +60,7 @@ class EventHub:
         """
         self.subscribers[event_type].remove(subscriber)
 
-    def peek(self, event: Event):
+    def peek(self, event: Event): #type: ignore
         """
         Check if an event exists in the queue.
         """

--- a/scripts/nqp/processors/intent.py
+++ b/scripts/nqp/processors/intent.py
@@ -19,6 +19,7 @@ from scripts.engine.internal.constant import (
     TargetingMethod,
     UIElement,
 )
+from scripts.engine.internal.event import EndTurnEvent, event_hub
 from scripts.engine.world_objects.tile import Tile
 from scripts.nqp import command
 from scripts.nqp.processors.targeting import targeting
@@ -135,7 +136,9 @@ def _process_game_map_intents(intent: InputIntentType):
         target_tile = world.get_tile((position.x, position.y))
         move = world.get_known_skill(player, "Move")
         if direction in move.target_directions:
-            _process_skill_use(player, move, target_tile, direction)
+            # ensure it's actually the player's turn by checking the event queue for an unprocessed end turn event
+            if not event_hub.peek(EndTurnEvent):
+                _process_skill_use(player, move, target_tile, direction)
 
     ## Use a skill
     elif intent in possible_skill_intents and position:


### PR DESCRIPTION
Fixed #122 by adding peeking functionality to the event system so we can ensure that there isn't an end turn event waiting in queue when the player tries to move. That said, you can visually still move diagonally. It just processes the turns correctly and lets other entities take 2 actions. If we want to get rid of the visual diagonal movement, we need to stop entities from taking actions before animations from the previous turn have finished. That's a different and slightly larger issue though.