### PR TITLE
feature/blessings

### DIFF
--- a/data/game/blessings.json
+++ b/data/game/blessings.json
@@ -3,6 +3,7 @@
     "name": "Move Fast???",
     "description": "move farther per movement I guess?",
     "removable": true,
+    "conflicts": [],
     "base_effects": {
       "remove_effects": [],
       "add_effects": [],
@@ -47,6 +48,44 @@
             }
           ]
         }
+      }
+    }
+  },
+  "NoMove": {
+    "name": "Stuck lol",
+    "description": "no moving >:(",
+    "removable": true,
+    "conflicts": ["AttackMove"],
+    "base_effects": {
+      "remove_effects": ["MoveSelfEffect"],
+      "add_effects": [],
+      "modify_effects_set": [],
+      "modify_effects_tweak_flat": [],
+      "modify_effects_tweak_percent": []
+    },
+    "levels": {
+      "Common": {
+        "rarity": 1,
+        "effects": {}
+      }
+    }
+  },
+  "AttackMove": {
+    "name": "AddEffectTest",
+    "description": "vroom",
+    "removable": true,
+    "conflicts": ["NoMove"],
+    "base_effects": {
+      "remove_effects": ["MoveSelfEffect"],
+      "add_effects": [{"effect_id": "MoveSelfEffect", "args": {"direction": [1, 0], "move_amount": 1}}],
+      "modify_effects_set": [],
+      "modify_effects_tweak_flat": [],
+      "modify_effects_tweak_percent": []
+    },
+    "levels": {
+      "Common": {
+        "rarity": 1,
+        "effects": {}
       }
     }
   }

--- a/data/game/blessings.json
+++ b/data/game/blessings.json
@@ -1,0 +1,53 @@
+{
+  "MoveFast": {
+    "name": "Move Fast???",
+    "description": "move farther per movement I guess?",
+    "removable": true,
+    "base_effects": {
+      "remove_effects": [],
+      "add_effects": [],
+      "modify_effects_set": [],
+      "modify_effects_tweak_flat": [
+        {
+          "effect_id": "MoveSelfEffect",
+          "values": {
+            "move_amount": 1
+          }
+        }
+      ],
+      "modify_effects_tweak_percent": []
+    },
+    "levels": {
+      "Common": {
+        "rarity": 0.7,
+        "effects": {}
+      },
+      "Rare": {
+        "rarity": 0.25,
+        "effects": {
+          "modify_effects_tweak_flat": [
+            {
+              "effect_id": "MoveSelfEffect",
+              "values": {
+                "move_amount": 2
+              }
+            }
+          ]
+        }
+      },
+      "Common": {
+        "rarity": 0.05,
+        "effects": {
+          "modify_effects_tweak_flat": [
+            {
+              "effect_id": "MoveSelfEffect",
+              "values": {
+                "move_amount": 3
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/scripts/engine/core/blessing.py
+++ b/scripts/engine/core/blessing.py
@@ -1,6 +1,11 @@
 import random
 from abc import ABC, abstractmethod
-from typing import List, Tuple, Dict, Any, TYPE_CHECKING
+from typing import List, Set, Tuple, Dict, Any, TYPE_CHECKING
+
+import scripts.engine.core.effect
+from scripts.engine.core.effect import Effect
+
+EFFECTS = {k : getattr(scripts.engine.core.effect, k) for k in dir(scripts.engine.core.effect)}
 
 class Blessing(ABC):
     """
@@ -22,8 +27,11 @@ class Blessing(ABC):
     modify_effects_tweak_flat: List[Dict[str, Any]]
     modify_effects_tweak_percent: List[Dict[str, Any]]
 
-    def __init__(self):
-        pass
+    # custom args (set by child if JSON doesn't cover the argument needs)
+    custom_args = {}
+
+    def __init__(self, owner):
+        self.owner = owner
 
     @classmethod
     def _init_properties(cls):
@@ -37,12 +45,20 @@ class Blessing(ABC):
         cls.description = cls.data['description']
         cls.level = 'Base' # assume common exists for now
         cls.removable = cls.data['removable']
+        cls.conflicts = cls.data['conflicts']
 
         cls.remove_effects = cls.data['base_effects']['remove_effects']
         cls.add_effects = cls.data['base_effects']['add_effects']
         cls.modify_effects_set = cls.data['base_effects']['modify_effects_set']
         cls.modify_effects_tweak_flat = cls.data['base_effects']['modify_effects_tweak_flat']
         cls.modify_effects_tweak_percent = cls.data['base_effects']['modify_effects_tweak_percent']
+
+    @property
+    def involved_effects(self) -> Set[str]:
+        """
+        Get the set of effects involved in the blessing.
+        """
+        return set([v['effect_id'] for v in self.add_effects + self.modify_effects_set] + self.remove_effects)
 
     def roll_level(self):
         """
@@ -52,9 +68,9 @@ class Blessing(ABC):
         level_chances = []
         total = 0
 
-        for level in cls.data['levels']:
-            rarities.append(level)
-            total += cls.data['levels'][level]['rarity']
+        for level in self.data['levels']:
+            levels.append(level)
+            total += self.data['levels'][level]['rarity']
             level_chances.append(total)
 
         random_float = random.random()
@@ -68,9 +84,56 @@ class Blessing(ABC):
         """
         Refreshes the class attributes with the data for the specific blessing level.
         """
-        cls.level = level
-        cls.remove_effects = cls.data['levels'][cls.level]['remove_effects']
-        cls.add_effects = cls.data['levels'][cls.level]['add_effects']
-        cls.modify_effects_set = cls.data['levels'][cls.level]['modify_effects_set']
-        cls.modify_effects_tweak_flat = cls.data['levels'][cls.level]['modify_effects_tweak_flat']
-        cls.modify_effects_tweak_percent = cls.data['levels'][cls.level]['modify_effects_tweak_percent']
+        self.level = level
+        if 'remove_effects' in self.data['levels'][self.level]['effects']:
+            self.remove_effects = self.data['levels'][self.level]['effects']['remove_effects']
+        if 'add_effects' in self.data['levels'][self.level]['effects']:
+            self.add_effects = self.data['levels'][self.level]['effects']['add_effects']
+        if 'modify_effects_set' in self.data['levels'][self.level]['effects']:
+            self.modify_effects_set = self.data['levels'][self.level]['effects']['modify_effects_set']
+        if 'modify_effects_tweak_flat' in self.data['levels'][self.level]['effects']:
+            self.modify_effects_tweak_flat = self.data['levels'][self.level]['effects']['modify_effects_tweak_flat']
+        if 'modify_effects_tweak_percent' in self.data['levels'][self.level]['effects']:
+            self.modify_effects_tweak_percent = self.data['levels'][self.level]['effects']['modify_effects_tweak_percent']
+
+    def apply(self, effects: List[Effect], owner, target):
+        """
+        This is the core function of the blessing. It takes the effect stack and modifies it with the blessing.
+        """
+
+        # go through the effects backwards so that the .remove() doesn't mess up indexing
+        for effect in effects[::-1]:
+            effect_name = effect.__class__.__name__
+
+            # flat config change
+            for mod in self.modify_effects_tweak_flat:
+                if mod['effect_id'] == effect_name:
+                    for value in mod['values']:
+                        current_value = getattr(effect, value)
+                        setattr(effect, value, current_value + mod['values'][value])
+
+            # set config change
+            for mod in self.modify_effects_set:
+                if mod['effect_id'] == effect_name:
+                    for value in mod['values']:
+                        setattr(effect, value, mod['values'][value])
+
+            # percent config change
+            for mod in self.modify_effects_tweak_percent:
+                if mod['effect_id'] == effect_name:
+                    for value in mod['values']:
+                        current_value = getattr(effect, value)
+                        setattr(effect, value, current_value * mod['values'][value])
+
+            # remove effects from the stack if applicable
+            if effect_name in self.remove_effects:
+                effects.remove(effect)
+
+        # add effects to the stack
+        for effect in self.add_effects:
+            # build the effect creation arguments from the config
+            args = {'origin': owner, 'target': target, 'success_effects': [], 'failure_effects': []}
+            args.update(effect['args'])
+            if effect['effect_id'] in self.custom_args:
+                args.update(self.custom_args)
+            effects.append(EFFECTS[effect['effect_id']](**args))

--- a/scripts/engine/core/blessing.py
+++ b/scripts/engine/core/blessing.py
@@ -1,0 +1,76 @@
+import random
+from abc import ABC, abstractmethod
+from typing import List, Tuple, Dict, Any, TYPE_CHECKING
+
+class Blessing(ABC):
+    """
+    The base class for blessings. Blessings modify skills through the effects applied.
+    """
+
+    name: str
+    description: str
+
+    level: str
+    removable: bool
+
+    # remove/add are applied when the blessing is applied
+    remove_effects: List[str]
+    add_effects: List[str]
+
+    # modifications are applied when the effects are built
+    modify_effects_set: List[Dict[str, Any]]
+    modify_effects_tweak_flat: List[Dict[str, Any]]
+    modify_effects_tweak_percent: List[Dict[str, Any]]
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def _init_properties(cls):
+        """
+        Sets the class properties of the blessing from the class key
+        """
+        from scripts.engine.internal import library
+
+        cls.data = library.BLESSINGS[cls.__name__]
+        cls.name = cls.__name__
+        cls.description = cls.data['description']
+        cls.level = 'Base' # assume common exists for now
+        cls.removable = cls.data['removable']
+
+        cls.remove_effects = cls.data['base_effects']['remove_effects']
+        cls.add_effects = cls.data['base_effects']['add_effects']
+        cls.modify_effects_set = cls.data['base_effects']['modify_effects_set']
+        cls.modify_effects_tweak_flat = cls.data['base_effects']['modify_effects_tweak_flat']
+        cls.modify_effects_tweak_percent = cls.data['base_effects']['modify_effects_tweak_percent']
+
+    def roll_level(self):
+        """
+        Runs the level selection algorithm and updates attributes with the applied level.
+        """
+        levels = []
+        level_chances = []
+        total = 0
+
+        for level in cls.data['levels']:
+            rarities.append(level)
+            total += cls.data['levels'][level]['rarity']
+            level_chances.append(total)
+
+        random_float = random.random()
+        for i, chance in enumerate(level_chances):
+            if random_float <= chance:
+                break
+
+        self.set_level(levels[i])
+
+    def set_level(self, level):
+        """
+        Refreshes the class attributes with the data for the specific blessing level.
+        """
+        cls.level = level
+        cls.remove_effects = cls.data['levels'][cls.level]['remove_effects']
+        cls.add_effects = cls.data['levels'][cls.level]['add_effects']
+        cls.modify_effects_set = cls.data['levels'][cls.level]['modify_effects_set']
+        cls.modify_effects_tweak_flat = cls.data['levels'][cls.level]['modify_effects_tweak_flat']
+        cls.modify_effects_tweak_percent = cls.data['levels'][cls.level]['modify_effects_tweak_percent']

--- a/scripts/engine/core/component.py
+++ b/scripts/engine/core/component.py
@@ -447,7 +447,7 @@ class Knowledge(NQPComponent):
         self.cooldowns: Dict[str, int] = cooldowns
         self.skill_names: List[str] = []  # TODO - do we even need this anymore?
         self.skills: Dict[str, Type[Skill]] = {}  # dont set skills here, use learn skill
-        #self.skill_blessings: Dict[str, Blessing] = {}
+        self.skill_blessings: Dict[str, Blessing] = {}
 
         for skill_class in skills:
             self.add(skill_class, _add_to_order, _set_cooldown)
@@ -468,6 +468,49 @@ class Knowledge(NQPComponent):
             self.skill_order.append(skill.__name__)
         if set_cooldown:
             self.cooldowns[skill.__name__] = 0
+
+    def add_blessing(self, skill: Type[Skill], blessing: Blessing) -> bool:
+        """
+        Add a new blessing.
+        """
+
+        # generate blessing level (this will probably be moved somewhere else later)
+        blessing.roll_level()
+
+        # create blessing list for the target skill if it doesn't exist yet
+        if skill.__name__ not in self.skill_blessings:
+            self.skill_blessings[skill.__name__] = []
+
+        # use sets to check for and prevent collisions (modifying the same effect, specified conflicts, duplicates, etc.)
+        used_effects = set()
+        blessing_names = set()
+        for b in self.skill_blessings[skill.__name__]:
+            used_effects = used_effects.union(b.involved_effects)
+            blessing_names = blessing_names.union({b.__class__.__name__})
+
+        if used_effects.intersection(blessing.involved_effects):
+            return False
+        elif blessing.__class__.__name__ in blessing_names:
+            return False
+        elif set(blessing.conflicts).intersection(blessing_names):
+            return False
+        else:
+            # finally add the blessing if it passed all of the other cases
+            self.skill_blessings[skill.__name__].append(blessing)
+
+        return True
+
+    def remove_blessing(self, skill: Type[Skill], remove_blessing: Type[Blessing]) -> bool:
+        """
+        Attempt to remove a blessing.
+        """
+        if remove_blessing.removable:
+            if skill.__name__ in self.skill_blessings:
+                for blessing in self.skill_blessings[skill.__name__]:
+                    if blessing.__class__.__name__ == remove_blessing.__name__:
+                        self.skill_blessings[skill.__name__].remove(blessing)
+                        return True
+        return False
 
     def serialize(self):
         _dict = {"skill_names": self.skill_names, "cooldowns": self.cooldowns, "skill_order": self.skill_order}

--- a/scripts/engine/core/component.py
+++ b/scripts/engine/core/component.py
@@ -447,6 +447,7 @@ class Knowledge(NQPComponent):
         self.cooldowns: Dict[str, int] = cooldowns
         self.skill_names: List[str] = []  # TODO - do we even need this anymore?
         self.skills: Dict[str, Type[Skill]] = {}  # dont set skills here, use learn skill
+        #self.skill_blessings: Dict[str, Blessing] = {}
 
         for skill_class in skills:
             self.add(skill_class, _add_to_order, _set_cooldown)

--- a/scripts/engine/internal/data.py
+++ b/scripts/engine/internal/data.py
@@ -7,6 +7,7 @@ from typing import List, TYPE_CHECKING
 import pygame
 from snecs.typedefs import EntityID
 
+from scripts.engine.core.blessing import Blessing
 from scripts.engine.internal.action import Affliction, Behaviour, Skill
 from scripts.engine.internal.constant import GameState
 
@@ -55,6 +56,7 @@ class Store:
         self.skill_registry: Dict[str, Type[Skill]] = {}
         self.affliction_registry: Dict[str, Type[Affliction]] = {}
         self.behaviour_registry: Dict[str, Type[Behaviour]] = {}
+        self.blessing_registry: Dict[str, Type[Blessing]] = {}
 
     def serialise(self) -> Dict[str, Any]:
         """

--- a/scripts/engine/internal/library.py
+++ b/scripts/engine/internal/library.py
@@ -96,6 +96,7 @@ def refresh_library():
     _load_secondary_stat_mod_data()
     _load_gods_data()
     _load_skills_data()
+    _load_blessings_data()
     _load_map_data()
     _load_room_data()
     _load_npc_data()
@@ -156,6 +157,12 @@ def _load_skills_data():
 
     SKILLS = data
 
+def _load_blessings_data():
+    with open(str(DATA_PATH / "game/blessings.json")) as file:
+        data = json.load(file, object_hook=deserialise_dataclasses)
+    global BLESSINGS
+
+    BLESSINGS = data
 
 def _load_map_data():
     with open(str(DATA_PATH / "game/maps.json")) as file:

--- a/scripts/nqp/actions/blessing.py
+++ b/scripts/nqp/actions/blessing.py
@@ -1,0 +1,5 @@
+from scripts.engine.core.blessing import Blessing
+
+class MoveFast(Blessing):
+    def __init__(self):
+        pass

--- a/scripts/nqp/actions/blessing.py
+++ b/scripts/nqp/actions/blessing.py
@@ -1,5 +1,24 @@
+from typing import List
+
+from scripts.engine.core.effect import Effect
 from scripts.engine.core.blessing import Blessing
 
+"""
+Use Blessing.custom_args to set custom effect initialization for a blessing if
+an object needs to be used (since objects can't be created in JSON).
+"""
+
 class MoveFast(Blessing):
-    def __init__(self):
-        pass
+    pass
+
+class NoMove(Blessing):
+    pass
+
+"""
+This is one example of how the blessing class can be used to modify blessings
+in a way that the JSON can't. The move target must be changed to the owner
+or this blessing won't work with skills that don't self-target.
+"""
+class AttackMove(Blessing):
+    def apply(self, effects: List[Effect], owner, target):
+        super().apply(effects, owner, owner)

--- a/scripts/nqp/actions/skill.py
+++ b/scripts/nqp/actions/skill.py
@@ -79,7 +79,7 @@ class Move(Skill):
             move_amount=1,
         )
 
-        return [move_effect]
+        return self._post_build_effects(entity, potency, [move_effect])
 
 
 class BasicAttack(Skill):
@@ -130,7 +130,7 @@ class BasicAttack(Skill):
             mod_amount=0.1,
         )
 
-        return [damage_effect]
+        return self._post_build_effects(entity, potency, [damage_effect])
 
 
 class Lunge(Skill):

--- a/scripts/nqp/command.py
+++ b/scripts/nqp/command.py
@@ -43,7 +43,7 @@ from scripts.engine.world_objects.game_map import GameMap
 from scripts.nqp.actions.affliction import BoggedDown, Flaming
 from scripts.nqp.actions.behaviour import FollowPlayer, SearchAndAttack, SkipTurn
 from scripts.nqp.actions.skill import BasicAttack, Lightning, Lunge, Move, Splash, TarAndFeather
-from scripts.nqp.actions.blessing import MoveFast
+from scripts.nqp.actions.blessing import MoveFast, NoMove, AttackMove
 from scripts.nqp.processors.game import GameEventSubscriber
 from scripts.nqp.ui_elements.camera import camera
 from scripts.nqp.ui_elements.character_selector import CharacterSelector
@@ -162,8 +162,11 @@ def start_game(player_data: ActorData):
     # allocate player skills
     world.learn_skill(player, "Lightning")
 
+    # blessing test cases
     knowledge = world.get_entitys_component(player, Knowledge)
-    #knowledge.skills['Move'].add_blessing()
+    #knowledge.add_blessing(Move, NoMove(player))
+    knowledge.add_blessing(BasicAttack, AttackMove(player))
+    knowledge.remove_blessing(BasicAttack, AttackMove)
 
     # create win condition and place next to player
     player_pos = world.get_entitys_component(player, Position)
@@ -390,6 +393,8 @@ def register_actions():
 
     # blessings
     register_action(MoveFast)
+    register_action(NoMove)
+    register_action(AttackMove)
 
 
 def init_subscribers():

--- a/scripts/nqp/command.py
+++ b/scripts/nqp/command.py
@@ -20,6 +20,7 @@ from scripts.engine.core.component import (
     MapCondition,
     Position,
     WinCondition,
+    Knowledge, # for demonstration purposes
 )
 from scripts.engine.core.ui import ui
 from scripts.engine.internal import library
@@ -42,6 +43,7 @@ from scripts.engine.world_objects.game_map import GameMap
 from scripts.nqp.actions.affliction import BoggedDown, Flaming
 from scripts.nqp.actions.behaviour import FollowPlayer, SearchAndAttack, SkipTurn
 from scripts.nqp.actions.skill import BasicAttack, Lightning, Lunge, Move, Splash, TarAndFeather
+from scripts.nqp.actions.blessing import MoveFast
 from scripts.nqp.processors.game import GameEventSubscriber
 from scripts.nqp.ui_elements.camera import camera
 from scripts.nqp.ui_elements.character_selector import CharacterSelector
@@ -159,6 +161,9 @@ def start_game(player_data: ActorData):
 
     # allocate player skills
     world.learn_skill(player, "Lightning")
+
+    knowledge = world.get_entitys_component(player, Knowledge)
+    #knowledge.skills['Move'].add_blessing()
 
     # create win condition and place next to player
     player_pos = world.get_entitys_component(player, Position)
@@ -382,6 +387,9 @@ def register_actions():
     register_action(TarAndFeather)
     register_action(Splash)
     register_action(Lightning)
+
+    # blessings
+    register_action(MoveFast)
 
 
 def init_subscribers():


### PR DESCRIPTION
This implements all listed functionality from #30 with the exception of requirement 8 (will be implemented in a later commit).
There are some scuffed things with the script names and locations (2 `blessing.py`s for example) that will also be fixed in the next commit.

Blessings can be configured from `data/game/blessings.json`. They must be registered in `scripts/nqp/actions/blessing.py` and `register_actions()` under `scripts/nqp/command.py`. `scripts/nqp/actions/blessing.py` can also be used to handle some edge cases that require more extensive blessing functionality than the JSON config can provide.

There are some examples of adding and removing blessings starting at line 165 in `command.py` (under the game start). The example code adds and removes the same blessings, so there shouldn't be any changes by default. All existing blessings at this point are example/test blessings.
